### PR TITLE
Implement backspace handling

### DIFF
--- a/drivers/keyboard.c
+++ b/drivers/keyboard.c
@@ -2,6 +2,7 @@
 #include "cpu/isr.h"
 #include "cpu/memlayout.h"
 #include "console.h"
+#include "vga.h"
 #include "port.h"
 #include "kernel/mem.h"
 
@@ -39,13 +40,23 @@ static void interrupt_handler(registers_t *r) {
      * simply update our state and do not output anything.
      */
     enum {
-        LSHIFT_PRESS  = 0x2a,
-        LSHIFT_RELEASE = 0xaa,
-        RSHIFT_PRESS  = 0x36,
-        RSHIFT_RELEASE = 0xb6,
+        BACKSPACE       = 0x0e,
+        BACKSPACE_REL   = 0x8e,
+        LSHIFT_PRESS    = 0x2a,
+        LSHIFT_RELEASE  = 0xaa,
+        RSHIFT_PRESS    = 0x36,
+        RSHIFT_RELEASE  = 0xb6,
     };
 
-    if (scancode == LSHIFT_PRESS) {
+    if (scancode == BACKSPACE) {
+        if (kbd_buf_size > 0) {
+            kbd_buf_size--;
+            vga_backspace();
+        }
+        return;
+    } else if (scancode == BACKSPACE_REL) {
+        return;
+    } else if (scancode == LSHIFT_PRESS) {
         lshift = 1;
         return;
     } else if (scancode == RSHIFT_PRESS) {

--- a/drivers/vga.c
+++ b/drivers/vga.c
@@ -65,6 +65,16 @@ void vga_set_char(unsigned offset, char c) {
     video_memory[2 * offset + 1] = get_color(light_gray, black);
 }
 
+void vga_backspace() {
+    unsigned offset = vga_get_cursor();
+    if (offset == 0) {
+        return;
+    }
+    offset--;
+    vga_set_cursor(offset);
+    vga_set_char(offset, ' ');
+}
+
 void vga_clear_screen() {
     for (unsigned i = 0; i < ROWS * COLS; ++i) {
         vga_set_char(i, ' ');

--- a/drivers/vga.h
+++ b/drivers/vga.h
@@ -4,5 +4,7 @@ void vga_clear_screen();
 
 void vga_print_string(const char* s);
 
+void vga_backspace();
+
 void vgaMode13();
 void vgaMode3();


### PR DESCRIPTION
## Summary
- add `vga_backspace` to erase the last character on the screen
- expose `vga_backspace` in header
- process Backspace scancode in keyboard interrupt handler

## Testing
- `make image.bin`
- `make test-nox` *(fails: ModuleNotFoundError: No module named 'qemu')*

------
https://chatgpt.com/codex/tasks/task_e_684ac024a02c8330afe64d5cc8eeb68e